### PR TITLE
DEVOPS-229: Fix boolean values for new settings and add description variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Available targets:
 | config_document | A JSON document describing the environment and instance metrics to publish to CloudWatch. | string | `{ "CloudWatchMetrics": {}, "Version": 1}` | no |
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| description | Short description of the Environment | string | `` | no |
 | enable_managed_actions | Enable managed platform updates.<br><br>When you set this to true, you must also specify a PreferredStartTime and UpdateLevel. | string | `true` | no |
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 | config_document | A JSON document describing the environment and instance metrics to publish to CloudWatch. | string | `{ "CloudWatchMetrics": {}, "Version": 1}` | no |
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| description | Short description of the Environment | string | `` | no |
 | enable_managed_actions | Enable managed platform updates.<br><br>When you set this to true, you must also specify a PreferredStartTime and UpdateLevel. | string | `true` | no |
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |

--- a/main.tf
+++ b/main.tf
@@ -329,6 +329,7 @@ resource "aws_security_group" "default" {
 resource "aws_elastic_beanstalk_environment" "default" {
   name        = "${module.label.id}"
   application = "${var.app}"
+  description = "${var.description}"
 
   tier                = "${var.tier}"
   solution_stack_name = "${var.solution_stack_name}"
@@ -606,12 +607,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
     name      = "HealthStreamingEnabled"
-    value     = "${var.health_streaming_enabled}"
+    value     = "${var.health_streaming_enabled ? "true" : "false"}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
     name      = "DeleteOnTerminate"
-    value     = "${var.health_streaming_delete_on_terminate}"
+    value     = "${var.health_streaming_delete_on_terminate ? "true" : "false"}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
@@ -666,7 +667,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "ManagedActionsEnabled"
-    value     = "${var.enable_managed_actions}"
+    value     = "${var.enable_managed_actions ? "true" : "false"}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,11 @@ variable "name" {
   description = "Solution name, e.g. 'app' or 'jenkins'"
 }
 
+variable "description" {
+  default     = ""
+  description = "Short description of the Environment"
+}
+
 variable "config_document" {
   default     = "{ \"CloudWatchMetrics\": {}, \"Version\": 1}"
   description = "A JSON document describing the environment and instance metrics to publish to CloudWatch."


### PR DESCRIPTION
## Problem

AWS expects `"true"` or `"false"` and not the interpolated value from TF.

## Solution

- Used conditionals on new values to ensure `"true"` or `"false"` are sent
- Added a new variable for environment description

## Testing

- Update `examples/complete/main.tf`'s source to `../../`
- Plan it
- Verify the plan completes successfully